### PR TITLE
Bump package version to 2.7.0

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 pkgname=leiningen
-pkgver=2.6.1
-pkgrel=1
+pkgver=2.7.0
+pkgrel=0
 pkgdesc="Automate Clojure projects without setting your hair on fire."
 url="https://leiningen.org"
 arch="noarch"
@@ -13,7 +13,7 @@ makedepends="$depends_dev openjdk8"
 install=""
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/technomancy/$pkgname/archive/$pkgver.tar.gz
-		$pkgname-$pkgver-standalone.jar::https://github.com/technomancy/$pkgname/releases/download/2.6.1/$pkgname-$pkgver-standalone.zip"
+		$pkgname-$pkgver-standalone.jar::https://github.com/technomancy/$pkgname/releases/download/$pkgver/$pkgname-$pkgver-standalone.zip"
 
 _builddir="$srcdir"/leiningen-$pkgver
 prepare() {
@@ -40,9 +40,9 @@ package() {
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-md5sums="9b431769e3230fd5cc2e3434df359971  leiningen-2.6.1.tar.gz
-a063df8011cc3e9151f155d9c1d4554a  leiningen-2.6.1-standalone.jar"
-sha256sums="9e6a6c7b6e032921a37d5be8fcdc2c0288d3698f759e22bdd29de4eb327ebeab  leiningen-2.6.1.tar.gz
-d70078fba85d5f405d042a6d7bad3a1e5b4aafae565c2d581feb999e95ae6394  leiningen-2.6.1-standalone.jar"
-sha512sums="20fea59b32ca008f30f897387257e378223a25c297af15526fe7d4eac0268d11b82dc94d3bc178266e3e396de1d03a323c9b579b2ba2ebb5bfad1ad5fb03e095  leiningen-2.6.1.tar.gz
-ec1a67976862987b72347bddb8f1e368ff0f01ef15d369f9af4f6184d0a9d4c98f47b8be968baab5d03c8571d7ad278097d044a41fe493f1e0169314bb96eb73  leiningen-2.6.1-standalone.jar"
+md5sums="122ea6e5fbe8d09741eb564920649be4  leiningen-2.7.0.tar.gz
+ae33517c5bce56f6e36f863bcc42cbea  leiningen-2.7.0-standalone.jar"
+sha256sums="db2069e9a87c72c7f83934e3068dc4b28c688115f7869056c4150392abc54c3d  leiningen-2.7.0.tar.gz
+b0a53fd9fa73e9d87c04ef25ba1ca174b0c062b803108648d7157176ccde7435  leiningen-2.7.0-standalone.jar"
+sha512sums="f5de842f24ad4bbbef66c228d4de08c351ec893464a4f70cf16cd62e11fb300ddc715945a4dec12912008df812ad1bc2b7d7fa66ca0f3f35d7125c7dead6c990  leiningen-2.7.0.tar.gz
+d42288c696d5b4d86c41a0ca9b8e748cdb9200c3adc23161b9b97b8c2f3da9c5bd811e2ddae265bf11d323b1449291e9914bf1e222aaf403e73ceef4084ed082  leiningen-2.7.0-standalone.jar"


### PR DESCRIPTION
💁  These changes bump the version of this package to [2.7.0](https://github.com/technomancy/leiningen/releases/tag/2.7.0).