### PR TITLE
Update artifacts path in CI build config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     - mkdir packages
     - echo -e "$RSA_PUBLIC_KEY" > packages/sgerrand.rsa.pub
   override:
-    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -e RSA_PRIVATE_KEY_NAME="sgerrand.rsa" -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages sgerrand/alpine-abuild
+    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -e RSA_PRIVATE_KEY_NAME="sgerrand.rsa" -v $(pwd):/home/builder/package -v $(pwd)/packages:/packages sgerrand/alpine-abuild
 
 test:
   override:


### PR DESCRIPTION
💁  The mount point for artifacts produced in the `sgerrand/alpine-abuild` Docker image changed, hence requiring an update to the build configuration.

Side note: I should have caught this by re-running #7 prior to merging it. 😾 