### PR TITLE
CircleCI: Prefer `go install` for `ghr`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: apk add --no-cache --no-progress git
-      - run: go get github.com/tcnksm/ghr
+      - run: go install github.com/tcnksm/ghr@latest
       - run:
           name: Release packages
           command: |


### PR DESCRIPTION
💁 The `go get` command was deprecated in Go v1.17 and is now reserved for use in modules. This change updates the command used to install `ghr` in CircleCI accordingly.

```
$ go get github.com/tcnksm/ghr
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.

Exited with code exit status 1
```

Closes #27 