### PR TITLE
CircleCI: Update previously missed installation of `ghr`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: apk add --no-cache --no-progress git
-      - run: go get github.com/tcnksm/ghr
+      - run: go install github.com/tcnksm/ghr@latest
       - run:
           name: Release packages
           command: |


### PR DESCRIPTION
💁 This change updates the remaining deprecated way of installing `ghr` – previously missed doing this as part of #28.